### PR TITLE
Governance: apply Botshare LTD IP and contribution baseline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Pull request
+
+Describe the change, validation, safety impact, and affected components.
+
+
+## Intellectual property and provenance
+
+- [ ] Every commit is signed off under the OpenAMRobot DCO.
+- [ ] I am covered by an accepted Individual or Corporate Contributor Agreement.
+- [ ] I have any required employer, university, client, sponsor, co-author, or institutional authorization.
+- [ ] I identified all third-party and material AI-assisted content with source, licence, modifications, and required notices.
+- [ ] I submitted no unauthorized confidential, personal, proprietary, credential, or export-controlled information.
+- [ ] I understand that accepted contributions are governed by the Contributor Agreement and the applicable outbound licence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,3 +215,14 @@ Maintainers are responsible for:
 - reviewing pull requests in their scope
 - maintaining code quality and consistency
 - helping contributors with architectural questions
+
+## Legal requirements
+
+OpenAMRobot is operated by **Botshare LTD**. Before a contribution can be accepted:
+
+1. every commit must be signed off under the [DCO](https://github.com/openAMRobot/.github/blob/main/DCO.md);
+2. the contributor must be covered by the applicable [Individual or Corporate Contributor Agreement](https://github.com/openAMRobot/.github/blob/main/CLA.md);
+3. any necessary employer, university, client, sponsor, co-author, or institutional authorization must be obtained; and
+4. third-party and material AI-assisted content must be disclosed with its source, licence, and required notices.
+
+The Contributor Agreement governs assignment of transferable economic rights in accepted contributions to Botshare LTD. DCO confirms provenance and authority but does not replace that agreement. Do not submit unauthorized confidential information, personal data, credentials, export-controlled material, or third-party material with unclear rights.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,8 @@
+# Notice
+
+
+## Botshare LTD and project ownership
+
+OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD**, Company ID HE479056, Chrysanthou Mylona 1, Panayides Building, Office 1, 3030 Limassol, Cyprus (alex@botshare.ai; https://botshare.ai).
+
+Copyright and transferable economic rights in original OpenAMRobot material are owned by Botshare LTD or used by it under applicable agreements. Accepted external contributions are governed by the OpenAMRobot Contributor Agreement. Botshare LTD does not claim ownership of third-party material; all authentic upstream ownership, licence, patent, attribution, and modification notices remain effective.

--- a/README.md
+++ b/README.md
@@ -415,3 +415,12 @@ We are working on information about the workflow, coding standards, and submissi
 
 This project is licensed under the MIT License. For more info please check `LICENSE` [LICENSE](https://github.com/openAMRobot/OpenAMR/blob/main/LICENSE) file in the root directory.
 
+## Ownership, licensing, and contributions
+
+OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD** (Cyprus Company ID HE479056). Botshare LTD owns the transferable economic rights in original OpenAMRobot material created by or validly assigned to it. Third-party material remains subject to its respective ownership, licences, and notices.
+
+Public distribution under this repository's applicable licence grants the permissions stated in that licence; it does not transfer ownership of underlying copyright, trademarks, patents, or other intellectual property.
+
+Accepted external contributions require DCO sign-off and an applicable Individual or Corporate Contributor Agreement governing assignment of transferable economic rights to Botshare LTD. Contributor attribution and legally non-waivable authorship or moral rights remain recognized.
+
+See the organization [IP Policy](https://github.com/openAMRobot/.github/blob/main/IP_POLICY.md), [Contribution Guide](https://github.com/openAMRobot/.github/blob/main/CONTRIBUTING.md), and [Contributor Agreement Process](https://github.com/openAMRobot/.github/blob/main/CLA.md).


### PR DESCRIPTION
## Summary

Applies the organization IP and contribution baseline without replacing this repository's technical guidance or third-party notices.

- identifies Botshare LTD as the OpenAMRobot project owner;
- explains the relationship between ownership and outbound licensing;
- requires DCO plus an accepted Individual or Corporate Contributor Agreement;
- adds contributor authority, third-party, confidentiality, and AI-assisted provenance checks;
- preserves existing repository-specific licence and attribution material.

Depends conceptually on openAMRobot/.github#26. No direct change to main and no organization settings change.