### PR TITLE
Revert "docs: cut legacy README to a redirect stub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,235 @@
-# OpenAMR (Legacy)
+# OpenAMRobot
 
-> **Status:** Archived, read only. Superseded by [openamr-platform-hw](https://github.com/openAMRobot/openamr-platform-hw).
+## Turn Domain Expertise into Robotic Skills by Demonstration
 
-This repository is kept for history. It is not maintained and its contents may be wrong. Do not build from it.
+### The Programming Language of Robotics is Domain Expertise.
 
-## Where the content went
+OpenAMRobot is an open-source Physical AI development platform that enables startups, researchers, universities, and domain experts to build, train, validate, and deploy robotic solutions without rebuilding the entire robotics stack.
 
-| What was here | Now lives in |
-| --- | --- |
-| Mechanical design, CAD, BOM, electrical, assembly files | [openamr-platform-hw](https://github.com/openAMRobot/openamr-platform-hw) |
-| ROS 2 stack, simulation, navigation, docking | [openamr-platform-sw](https://github.com/openAMRobot/openamr-platform-sw) |
-| Motor control, odometry, and telemetry firmware | [openamr-platform-fw](https://github.com/openAMRobot/openamr-platform-fw) |
+We believe the future of robotics will not be built by robotics engineers alone.
 
-The original README, including the 2024 spec sheet and the manufacturing notes, is preserved in git history: [README.md at 55ff20a](https://github.com/openAMRobot/openamr/blob/55ff20abcd69b9a12c95871083de4711360d1666/README.md). Those figures describe the Linorobot-era build and are superseded by the [validated hardware configuration](https://github.com/openAMRobot/openamr-platform-hw#current-validated-hardware-configuration) in openamr-platform-hw.
+It will be built by:
 
-## Start here instead
+- Manufacturing experts
+- Logistics specialists
+- Healthcare professionals
+- Researchers
+- Entrepreneurs
+- Innovators
 
-- Ecosystem overview: [openamrobot-docs](https://github.com/openAMRobot/openamrobot-docs)
-- Working release: [openamrobot-release](https://github.com/openAMRobot/openamrobot-release)
+People who understand problems and want to automate them.
+
+OpenAMRobot provides the infrastructure that transforms domain expertise into robotic capabilities.
+
+---
+
+# ⚠️ This Repository Has Moved
+
+OpenAMR has evolved into a modular, better organized project.
+
+As part of the **OpenAMRobot v0.0.1** release, the original repository has been split into dedicated repositories for hardware, software, firmware, and documentation.
+
+## 📢 What Happened?
+
+Most of the content previously available in this repository has been:
+
+- ➜ migrated to **openamr-platform-hw**
+- ➜ partially migrated to **openamr-platform-fw**
+- ➜ reorganized into a modular repository structure
+- ➜ updated with improved documentation and architecture
+
+The legacy repository is now kept mainly for historical reference.
+
+---
+## 📦 New Project Structure
+
+### 🛠️ Hardware
+https://github.com/openAMRobot/openamr-platform-hw
+
+Complete mechanical design, CAD, manufacturing files, BOM, electrical documentation, chassis, wiring, and assembly documentation.
+
+### 🤖 Software
+https://github.com/openAMRobot/openamr-platform-sw
+
+ROS 2 Jazzy, Nav2, Gazebo Harmonic, SLAM, autonomous navigation, auto-docking, UI, simulation, Docker, and robotics software.
+
+### ⚙️ Firmware
+https://github.com/openAMRobot/openamr-platform-fw
+
+micro-ROS firmware, motor control, odometry, IMU integration, PID control, telemetry, safety framework, and embedded software.
+
+---
+## 🚀 Watch the Release
+
+[![OpenAMRobot v0.0.1 Release](https://img.youtube.com/vi/LCLWUHWGkIY/maxresdefault.jpg)](https://www.youtube.com/shorts/LCLWUHWGkIY)
+
+▶️ **OpenAMRobot v0.0.1 — First Public Release**
+
+---
+
+## ❤️ Continue the Journey
+
+OpenAMRobot is becoming an open ecosystem for embodied AI, autonomous mobile robots, and mobile manipulation.
+
+If you're looking for the latest development, please start here:
+
+👉 https://github.com/openAMRobot
+
+⭐ Star the project if you'd like to support open robotics.
+
+---
+
+## Why OpenAMRobot?
+
+Building a modern Physical AI system requires expertise across:
+
+- Robotics
+- AI
+- Perception
+- Teleoperation
+- Data collection
+- Simulation
+- Training infrastructure
+- Deployment
+
+Most teams spend months assembling infrastructure before they can validate a single robotic application.
+
+OpenAMRobot reduces this complexity by providing an integrated development platform for:
+
+- Mobile manipulation
+- Teleoperation
+- Data collection
+- Imitation learning
+- Embodied AI research
+- Human-in-the-loop training
+- Robot skill development
+- Real-world deployment
+
+**The fastest path from business problem to robotic solution.**
+
+---
+
+## Robotics 3.0
+
+### Software evolution
+
+**Software 1.0**  
+Write code
+
+**Software 2.0**  
+Train models
+
+**Software 3.0**  
+Describe outcomes
+
+### Robotics evolution
+
+**Robotics 1.0**  
+Program robots
+
+**Robotics 2.0**  
+Train robots
+
+**Robotics 3.0**  
+Teach robots by demonstration
+
+OpenAMRobot is building the platform for Robotics 3.0.
+
+---
+
+## How it works
+
+Domain Expert  
+↓  
+Demonstrates Task  
+↓  
+OpenAMRobot Collects Data  
+↓  
+AI Learns Skill  
+↓  
+Robot Executes Task
+
+OpenAMRobot connects hardware, software, AI, and deployment into a single workflow.
+
+---
+
+## What OpenAMRobot provides
+
+### Reference hardware
+
+- Autonomous mobile robot platform
+- Dual-arm mobile manipulation
+- Adjustable lift systems
+- Modular sensor architecture
+- Open hardware designs
+
+### Software infrastructure
+
+- ROS 2 ecosystem
+- Navigation and autodocking
+- Teleoperation interfaces
+- Simulation environments
+- Embedded firmware
+
+### Physical AI infrastructure
+
+- Demonstration data collection
+- ROS bag recording
+- Dataset generation
+- Imitation learning pipelines
+- Foundation model integration
+- Policy training workflows
+- Deployment infrastructure
+
+---
+
+## Who is OpenAMRobot for?
+
+### Today
+
+- Robotics startups
+- Universities
+- Research laboratories
+- Corporate innovation teams
+- Venture builders
+
+### Tomorrow
+
+- Manufacturing
+- Logistics
+- Healthcare
+- Agriculture
+- Service robotics
+
+Our users build robots.
+
+Their users deploy robots.
+
+---
+
+## Why OpenAMRobot matters
+
+Physical AI is creating a new generation of robots that learn from demonstration, adapt to new tasks, and solve real-world problems.
+
+Yet building a trainable robot still requires expertise across hardware, software, AI, teleoperation, data collection, training pipelines, simulation, deployment, and hardware integration.
+
+OpenAMRobot reduces this complexity by providing an integrated platform that enables anyone with domain expertise to create robotic solutions.
+
+The real value is not the robot itself.
+
+The real value is how efficiently a robotic system can solve a business problem.
+
+---
+
+## Our vision
+
+The next generation of creators will not just build software.
+
+They will build robots.
+
+OpenAMRobot enables anyone with domain expertise to create robotic solutions without becoming a robotics engineer.
+
+**The Programming Language of Robotics is Domain Expertise.**
 
 ---
 
@@ -48,7 +260,158 @@ Support open-source robotics, ROS 2 development, AI robotics education, and dual
 
 **❤️ GitHub Sponsors:** <a href="https://github.com/sponsors/openAMRobot" target="_blank" rel="noopener noreferrer"> 🐙 &nbsp;github.com/sponsors/openAMRobot&nbsp;→</a>
 
-*Every contribution - €5 or €1,500 - literally builds this robot. No billion-dollar lab required. **You're not donating. You're building it.** 🤖*
+*Every contribution — €5 or €1,500 — literally builds this robot. No billion-dollar lab required. **You're not donating. You're building it.** 🤖*
 
----
+> [!IMPORTANT]
+> ## OpenAMRobot Ecosystem
+>
+> OpenAMRobot is transitioning from a monolithic repository structure into a modular robotics ecosystem.
+>
+> ![OpenAMRobot Ecosystem](docs/hardware/pictures/OpenAMRobot_ecosystem.png)
+>
+> ### Core Repositories
+>
+> | Repository | Purpose |
+> |---|---|
+> | `openamr-platform-sw` | ROS 2 software, simulation, navigation, docking, drivers, perception, and robot bringup |
+> | `openamr-platform-fw` | Embedded firmware, low-level microcontroller systems, motor interfaces, and hardware communication |
+> | `openamr-platform-hw` | CAD, chassis, electrical systems, BOMs, manufacturing files, and mechatronics |
+> | `openamrobot-interfaces` | ROS 2 messages, services, actions, shared schemas, and interface contracts |
+> | `openamrobot-comm` | APIs, middleware, telemetry, transport protocols, interoperability, and fleet communication |
+> | `openamrobot-ui` | Operator interfaces, dashboards, visualization tools, and user-facing applications |
+> | `openamrobot-docs` | Architecture, onboarding, tutorials, safety, compatibility matrices, and contributor documentation |
+>
+> ### Future Expansion
+>
+> Planned future ecosystem areas include:
+>
+> - humanoid and dual-arm robotics
+> - fleet management
+> - cloud robotics
+> - remote operation
+> - AI-assisted autonomy
+> - industrial integrations
+> - educational platforms
+>
+> ### Legacy Status
+>
+> This repository remains as a historical/community repository and migration hub while development transitions into the modular architecture.
+
+## Introduction
+
+SMEs across multiple industries can significantly enhance their operations through the adoption of Collaborative Dual-Arm Autonomous Mobile Robots. 
+In warehouses and distribution centers, such robots streamline goods movement and order fulfillment by combining autonomous navigation with dexterous dual-arm manipulation, enabling advanced G2P workflows and reducing manual handling. 
+In manufacturing environments, they improve production efficiency by autonomously transporting materials between workstations and performing basic assembly or handling tasks. 
+For last-mile logistics, including courier, express, parcel (CEP), and grocery delivery, dual-arm AMRs further boost operational efficiency by automating repetitive loading, sorting, and delivery operations.
+
+Our project empowers you to build your own AMR using open-source designs and accessible manufacturing methods. This guide provides detailed drawings, 3D models, Bill of Materials (BOM), hardware architecture, navigation software, and user interface packages. Utilize straightforward manufacturing technologies to learn and integrate advanced automation seamlessly into your business operations.
+
+## Key features
+
+- **Navigation**: LIDAR/SLAM
+- **Drive type**: Differential drive
+- **Weight**: ~60 kg
+- **Camera view**: 120 degrees
+- **Speed**: 1500-2000 mm/s (unloaded), 1200-1500 mm/s (loaded)
+- **Positioning accuracy**: ±20 mm
+- **Dimensions**: 600x800 mm
+- **Battery**: 24/48 V, 48-56 Ah, 8 hours life
+- **Communication**: Wi-Fi (2.4/5 GHz)
+- **Load capacity**: up to 150 kg
+- **Operating temperature**: -10°C to +50°C
+- **Charging**: Contact/wireless
+
+## Design and manufacturing
+
+Our design is optimized for manufacturability, requiring only basic technologies such as laser cutting, bending, turning (optional), and 3D printing (optional). Using mostly 2mm thick metal sheets, the design is robust yet simple to produce, allowing one person to build the robot in just one day if every part is ready.
+
+Here is how the chassis design looks like:
+
+![Mobile Robot General View](https://github.com/openAMRobot/OpenAMR/blob/main/docs/hardware/pictures/AMR_views.jpg)
+
+### Mechanical design and assembly
+
+1. **Downloadable resources**:
+    - Production drawings, 3D models, STEP, and DXF files
+    - Specification sheet, including all parts and assemblies, sensors, and fasteners
+2. **Fabrication process**:
+    - Discuss the drawings with a contractor for cutting and bending metal.
+    - Assemble the chassis following the provided sequence.
+3. **Assembly steps**:
+    - The chassis design and the recommended assembly sequence are illustrated in the provided images.
+    - Detailed steps for assembling the drive wheels and other components are included.
+
+### Hardware and software integration
+
+1. **Electronics block diagram**:
+    - Main single-board computer (SBC)
+    - Safety sensors (US, IR, bumper), RPI camera, and LiDAR
+    - Controller Teensy board and firmware
+    - BLDC motors, drivers, and encoders
+    - Batteries, BMS, and wireless charger
+    - On/Off switch and Emergency button
+
+2. **Main components**:
+    - **Raspberry Pi 5**: For main computing tasks.
+    - **LIDAR**: For mapping and navigation.
+    - **Sensors**: For obstacle detection and safety.
+    - **BLDC motors and drivers**: For movement control.
+    - **Battery system**: For power supply.
+    - **Wireless charging**: For autonomous charging.
+
+3. **Software setup**:
+    - **Linorobot**: Open-source software package for navigation and control.
+    - **UI**: Built with Flask and Java for user interaction.
+   
+To get all files you should do the next commands:
+
+        git clone https://github.com/openAMRobot/OpenAMR.git
+  
+        cd openAMR
+
+        git submodule update --init --recursive
+
+The **whole tutorial** about software installation is sectioned into different topics. Click [here](https://github.com/openAMRobot/OpenAMR/wiki/Getting-started) here to get started.
+      
+Here’s how the hardware architecture of the robot looks like:
+
+![Mobile Robot General View](https://github.com/openAMRobot/OpenAMR/blob/main/docs/hardware/pictures/HW_schema_article.jpg)
+
+### Practical applications and future enhancements
+
+This versatile design can be adapted to create different types of robots for various logistics tasks. It can also be modified to carry tools or a roller cage, increasing its usefulness in various scenarios. Examples of practical applications include:
+
+- Automating goods movement in warehouses
+- Enhancing production workflows in manufacturing plants
+- Improving operational efficiency in small farms and greenhouses
+
+## Conclusion
+
+This project provides a low-cost DIY autonomous mobile robot suitable for industrial automation or warehouse logistics. By open-sourcing our technology, we offer SMEs an opportunity to leverage advanced robotics without the high costs associated with research and development.
+
+For any questions, please refer to the documentation or the open-source project Linorobot. Basic knowledge of electronics, software, and mechanics is required.
+
+## Community management and moderation
+
+Effective community management and moderation are essential to maintain a healthy and productive environment for collaboration. Our project welcomes contributions and feedback from the community to improve and evolve.
+
+## Community profiles for public repositories
+
+We are working on rules and suggestions to manage contributions and interactions within our repository. They include features like issue templates, pull request templates, and guidelines for contributors and will be published soon.
+
+### A project's community profile
+
+You can access the community profile of this repository by clicking on the "Community" tab on the repository's main page. This section provides all the necessary information and resources for contributors.
+
+### A code of conduct 
+
+We are preparing standards for behavior within the community. Information about Code of Conduct will be added soon to a `CODE_OF_CONDUCT.md` file in the root directory. Where we will outline the expected behavior and the process for reporting violations.
+
+### Guidelines for repository contributors
+
+We are working on information about the workflow, coding standards, and submission process to help contributors understand the best practices and expectations. This information will be outlined in a `CONTRIBUTING.md` file.
+
+### License
+
+This project is licensed under the MIT License. For more info please check `LICENSE` [LICENSE](https://github.com/openAMRobot/OpenAMR/blob/main/LICENSE) file in the root directory.
 


### PR DESCRIPTION
Reverts [#23](https://github.com/openAMRobot/openamr/pull/23).

`README.md` is restored to its state at `55ff20a`, byte for byte: 18,290 bytes.

## Why

`openamr` is legacy but stays active while the transition from the mono-repo to the multi-repo structure completes. #23 marked it "Archived, read only" and told readers "Do not build from it", which is wrong for a repository people are still using.

The original README already does what is needed here:

- Describes the move from a single repository to the distributed structure.
- Links to `openamr-platform-hw`, `openamr-platform-sw`, and `openamr-platform-fw` with a short description of what each now holds.
- Keeps the spec sheet, build steps, and support section.

So it is restored intact rather than rewritten.
